### PR TITLE
changed request code & added check for it in onActivityResult

### DIFF
--- a/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxModule.java
+++ b/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxModule.java
@@ -13,6 +13,7 @@ class LocationServicesDialogBoxModule extends ReactContextBaseJavaModule impleme
     private Promise promiseCallback;
     private ReadableMap map;
     private Activity currentActivity;
+    private static final int ENABLE_LOCATION_SERVICES = 1009;
 
     LocationServicesDialogBoxModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -60,7 +61,7 @@ class LocationServicesDialogBoxModule extends ReactContextBaseJavaModule impleme
                 .setPositiveButton(configMap.getString("ok"),
                         new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialogInterface, int id) {
-                                activity.startActivityForResult(new Intent(action), 1);
+                                activity.startActivityForResult(new Intent(action), ENABLE_LOCATION_SERVICES);
                                 dialogInterface.dismiss();
                             }
                         })
@@ -76,7 +77,9 @@ class LocationServicesDialogBoxModule extends ReactContextBaseJavaModule impleme
 
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
-        currentActivity = activity;
-        checkLocationService(true);
+        if(requestCode == ENABLE_LOCATION_SERVICES) {
+            currentActivity = activity;
+            checkLocationService(true);
+        }
     }
 }


### PR DESCRIPTION
Using request code as 1 is pretty common and there will be conflicts, so I chose something a bit more random. Furthermore, there needs to be a check for the request code in onActivityResult, otherwise it will execute every time any (unrelated) activity in the app is finished with a result.

Fixes https://github.com/webyonet/react-native-android-location-services-dialog-box/issues/9.