### PR TITLE
Make using high accuracy configurable

### DIFF
--- a/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxModule.java
+++ b/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxModule.java
@@ -42,7 +42,11 @@ class LocationServicesDialogBoxModule extends ReactContextBaseJavaModule impleme
         if (currentActivity == null || map == null || promiseCallback == null) return;
         LocationManager locationManager = (LocationManager) currentActivity.getSystemService(Context.LOCATION_SERVICE);
 
-        if (!locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER) || !locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)) {
+        Boolean isEnabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+        if (!map.hasKey("enableHighAccuracy") || map.getBoolean("enableHighAccuracy")) {
+            isEnabled = isEnabled && locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+        }
+        if (!isEnabled) {
             if (activityResult) {
                 promiseCallback.reject(new Throwable("disabled"));
             } else {


### PR DESCRIPTION
**Make using high accuracy configurable**

Preserve the default behavior and allow configuring {enableHighAccuracy: false}
Named the prop the same as navigator.geolocation's setting.