### PR TITLE
Remove createJSModules

### DIFF
--- a/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxPackage.java
+++ b/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxPackage.java
@@ -19,11 +19,6 @@ public class LocationServicesDialogBoxPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactApplicationContext) {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxPackage.java
+++ b/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxPackage.java
@@ -17,10 +17,10 @@ public class LocationServicesDialogBoxPackage implements ReactPackage {
         modules.add(new LocationServicesDialogBoxModule(reactApplicationContext));
         return modules;
     }
-    
+
     // Deprecated RN 0.47
-    public List<Class<? extends JavaScriptModule>> createJSModules() {		
-        return Collections.emptyList();		
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxPackage.java
+++ b/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxPackage.java
@@ -18,6 +18,7 @@ public class LocationServicesDialogBoxPackage implements ReactPackage {
         return modules;
     }
     
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {		
         return Collections.emptyList();		
     }

--- a/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxPackage.java
+++ b/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxPackage.java
@@ -17,6 +17,10 @@ public class LocationServicesDialogBoxPackage implements ReactPackage {
         modules.add(new LocationServicesDialogBoxModule(reactApplicationContext));
         return modules;
     }
+    
+    public List<Class<? extends JavaScriptModule>> createJSModules() {		
+        return Collections.emptyList();		
+    }
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactApplicationContext) {


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8). I actually can't build an app on RN 0.47 without removing this method/ovveride marker.