### PR TITLE
FIX: "Illegal callback invocation from native module."

### DIFF
--- a/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxModule.java
+++ b/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxModule.java
@@ -49,7 +49,6 @@ public class LocationServicesDialogBoxModule extends ReactContextBaseJavaModule 
     @ReactMethod
     public void forceCloseDialog() {
         if (alertDialog != null && promiseCallback != null) {
-            promiseCallback.reject(new Throwable("disabled"));
             alertDialog.cancel();
         }
     }


### PR DESCRIPTION
Currently when we call `forceCloseDialog` this error appears.

```
02-13 14:43:20.682 18474 18534 E unknown:ReactNative: Exception in native call
02-13 14:43:20.682 18474 18534 E unknown:ReactNative: java.lang.RuntimeException: Illegal callback invocation from native module. This callback type only permits a single invocation from native code.
02-13 14:43:20.682 18474 18534 E unknown:ReactNative:   at com.facebook.react.bridge.CallbackImpl.invoke(CallbackImpl.java:28)
02-13 14:43:20.682 18474 18534 E unknown:ReactNative:   at com.facebook.react.bridge.PromiseImpl.reject(PromiseImpl.java:68)
02-13 14:43:20.682 18474 18534 E unknown:ReactNative:   at com.facebook.react.bridge.PromiseImpl.reject(PromiseImpl.java:52)
02-13 14:43:20.682 18474 18534 E unknown:ReactNative:   at com.showlocationservicesdialogbox.LocationServicesDialogBoxModule.forceCloseDialog(LocationServicesDialogBoxModule.java:52)
02-13 14:43:20.682 18474 18534 E unknown:ReactNative:   at java.lang.reflect.Method.invoke(Native Method)
02-13 14:43:20.682 18474 18534 E unknown:ReactNative:   at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
02-13 14:43:20.682 18474 18534 E unknown:ReactNative:   at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:160)
02-13 14:43:20.682 18474 18534 E unknown:ReactNative:   at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
02-13 14:43:20.682 18474 18534 E unknown:ReactNative:   at android.os.Handler.handleCallback(Handler.java:790)
02-13 14:43:20.682 18474 18534 E unknown:ReactNative:   at android.os.Handler.dispatchMessage(Handler.java:99)
02-13 14:43:20.682 18474 18534 E unknown:ReactNative:   at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:29)
02-13 14:43:20.682 18474 18534 E unknown:ReactNative:   at android.os.Looper.loop(Looper.java:164)
02-13 14:43:20.682 18474 18534 E unknown:ReactNative:   at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run(MessageQueueThreadImpl.java:192)
02-13 14:43:20.682 18474 18534 E unknown:ReactNative:   at java.lang.Thread.run(Thread.java:764)
```
Similar issue. https://github.com/webyonet/react-native-android-location-services-dialog-box/issues/43

