### PR TITLE
Use the enableHighAccuracy parameter in the listener as well.

### DIFF
--- a/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxModule.java
+++ b/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxModule.java
@@ -70,16 +70,7 @@ public class LocationServicesDialogBoxModule extends ReactContextBaseJavaModule 
         LocationManager locationManager = (LocationManager) currentActivity.getSystemService(Context.LOCATION_SERVICE);
         WritableMap result = Arguments.createMap();
 
-        Boolean isEnabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
-
-        if (map.hasKey("enableHighAccuracy") && map.getBoolean("enableHighAccuracy")) {
-            // High accuracy needed. Require NETWORK_PROVIDER.
-            isEnabled = isEnabled && locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
-        } else {
-            // Either highAccuracy is not a must which means any location will suffice
-            // or it is not specified which means again that any location will do.
-            isEnabled = isEnabled || locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
-        }
+        Boolean isEnabled = this.isEnabled(locationManager);
 
         if (!isEnabled) {
             if (activityResult || map.hasKey("openLocationServices") && !map.getBoolean("openLocationServices")) {
@@ -187,12 +178,28 @@ public class LocationServicesDialogBoxModule extends ReactContextBaseJavaModule 
         }
     }
 
+    private Boolean isEnabled(LocationManager locationManager) {
+        Boolean enabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+        if (map != null) {
+            if (map.hasKey("enableHighAccuracy") && map.getBoolean("enableHighAccuracy")) {
+                // High accuracy needed. Require NETWORK_PROVIDER.
+                enabled = enabled && locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+            } else {
+                // Either highAccuracy is not a must which means any location will suffice
+                // or it is not specified which means again that any location will do.
+                enabled = enabled || locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+            }
+        }
+
+        return enabled;
+    }
+
     private void sendEvent() {
         if (isReceive) {
             LocationManager locationManager = (LocationManager) currentActivity.getSystemService(Context.LOCATION_SERVICE);
             WritableMap params = Arguments.createMap();
             if (locationManager != null) {
-                boolean enabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+                boolean enabled = this.isEnabled(locationManager);
 
                 params.putString("status", (enabled ? "enabled" : "disabled"));
                 params.putBoolean("enabled", enabled);

--- a/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxModule.java
+++ b/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxModule.java
@@ -75,6 +75,9 @@ public class LocationServicesDialogBoxModule extends ReactContextBaseJavaModule 
         if (!isEnabled) {
             if (activityResult || map.hasKey("openLocationServices") && !map.getBoolean("openLocationServices")) {
                 promiseCallback.reject(new Throwable("disabled"));
+                if (map.hasKey("providerListener") && map.getBoolean("providerListener")) {
+                    startListener();
+                }
             } else if (!map.hasKey("showDialog") || map.getBoolean("showDialog")) {
                 displayPromptForEnablingGPS(currentActivity, map, promiseCallback);
             } else {


### PR DESCRIPTION
The accuracy parameter wasn't reflected in the event, thus when checking if low accuracy is enabled and enabling the events, the status that was given only checked whether the GPS provider was enabled, resulting in a change where the status didn't change.

Extracted the function to check whether the location services are enabled based on the parameters given to the function.

Possible improvement might be to fire an event which returns something like:
```js
{
  "enabled": hasGPS, // To be backwards compatible
  "lowAccuracy": hasGPS || hasNetwork,
  "highAccuracy": hasGPS && hasNetwork
}
```

I also found a bug that the listener only started when the location services were turned on. When silently checking for the location services, the listener wouldn't start. The listener is now also started when the services were not enabled.