### PR TITLE
compile -> compileOnly in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    compileOnly 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018.