### PR TITLE
FIX: Fatal Exception: java.lang.IllegalArgumentException in forceCloseDialog

### DIFF
--- a/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxModule.java
+++ b/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxModule.java
@@ -48,9 +48,11 @@ public class LocationServicesDialogBoxModule extends ReactContextBaseJavaModule 
 
     @ReactMethod
     public void forceCloseDialog() {
-        if (alertDialog != null && promiseCallback != null) {
-            alertDialog.cancel();
-        }
+        try {
+            if (alertDialog != null && alertDialog.isShowing() && promiseCallback != null) {
+                alertDialog.cancel();
+            }
+        } catch (Exception ignored) {}
     }
 
     @ReactMethod


### PR DESCRIPTION
```
Fatal Exception: java.lang.IllegalArgumentException: View=DecorView@6443101[MainActivity] not attached to window manager
       at android.view.WindowManagerGlobal.findViewLocked + 533(WindowManagerGlobal.java:533)
       at android.view.WindowManagerGlobal.removeView + 433(WindowManagerGlobal.java:433)
       at android.view.WindowManagerImpl.removeViewImmediate + 124(WindowManagerImpl.java:124)
       at android.app.Dialog.dismissDialog + 518(Dialog.java:518)
       at android.app.Dialog.dismiss + 501(Dialog.java:501)
       at android.app.Dialog.cancel + 1462(Dialog.java:1462)
       at com.showlocationservicesdialogbox.LocationServicesDialogBoxModule.forceCloseDialog + 52(LocationServicesDialogBoxModule.java:52)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.facebook.react.bridge.JavaMethodWrapper.invoke + 372(JavaMethodWrapper.java:372)
       at com.facebook.react.bridge.JavaModuleWrapper.invoke + 158(JavaModuleWrapper.java:158)
       at com.facebook.react.bridge.queue.NativeRunnable.run(NativeRunnable.java)
       at android.os.Handler.handleCallback + 873(Handler.java:873)
       at android.os.Handler.dispatchMessage + 99(Handler.java:99)
       at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage + 29(MessageQueueThreadHandler.java:29)
       at android.os.Looper.loop + 214(Looper.java:214)
       at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run + 232(MessageQueueThreadImpl.java:232)
       at java.lang.Thread.run + 764(Thread.java:764)
```